### PR TITLE
updates ternaries for getAllMaterials and getAllFamilies to properly use the corresponding reducers

### DIFF
--- a/src/datasources/earth.js
+++ b/src/datasources/earth.js
@@ -15,7 +15,7 @@ class EarthAPI extends RESTDataSource {
   }
   familyReducer(family) {
     return {
-      material_ids: family.material_id,
+      material_ids: family.material_ids,
       family_id: family.family_id,
       description: family.description,
       family_type_id: family.family_type_id
@@ -24,14 +24,18 @@ class EarthAPI extends RESTDataSource {
   async getAllMaterials() {
     const response = await this.get(`earth911.getMaterials${this.apiKey}`);
     const result = JSON.parse(response).result;
-    return Array.isArray(result) ? result : [];
+    return Array.isArray(result)
+      ? result.map(material => this.materialReducer(material))
+      : [];
   }
   async getAllFamilies() {
     const response = await this.get(
       `earth911.getFamilies${this.apiKey}&family_type_id=1`
     );
     const result = JSON.parse(response).result;
-    return Array.isArray(result) ? result : [];
+    return Array.isArray(result)
+      ? result.map(family => this.familyReducer(family))
+      : [];
   }
 }
 


### PR DESCRIPTION
# Description
getAllMaterials and getAllFamilies had been working, but not taking advantage of the reducers. That has been changed and now is working properly. 

Fixes #23 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [x] Complete, tested, ready to review and merge


# How Has This Been Tested?

Returns the same data as it had prior.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
