### PR TITLE
getMaterial

### DIFF
--- a/src/datasources/earth.js
+++ b/src/datasources/earth.js
@@ -8,6 +8,7 @@ class EarthAPI extends RESTDataSource {
   }
   materialReducer(material) {
     return {
+      id: material.material_id,
       description: material.description,
       material_id: material.material_id,
       long_description: material.long_description
@@ -36,6 +37,13 @@ class EarthAPI extends RESTDataSource {
     return Array.isArray(result)
       ? result.map(family => this.familyReducer(family))
       : [];
+  }
+  async getMaterial({ material_id }) {
+    const response = await this.get(`earth911.getMaterials${this.apiKey}`, {
+      material_id
+    });
+    const material = JSON.parse(response).result;
+    return this.materialReducer(material[material_id]);
   }
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -2,6 +2,8 @@ module.exports = {
   Query: {
     materials: (_, __, { dataSources }) =>
       dataSources.earthAPI.getAllMaterials(),
+    material: (_, { id }, { dataSources }) =>
+      dataSources.earthAPI.getMaterial({ material_id: id }),
     families: (_, __, { dataSources }) => dataSources.earthAPI.getAllFamilies()
   }
 };

--- a/src/schema.js
+++ b/src/schema.js
@@ -2,7 +2,7 @@ const { gql } = require("apollo-server");
 
 const typeDefs = gql`
   type Query {
-    material: Material
+    material(id: Int): Material
     materials: [Material]
     family: Family
     families: [Family]


### PR DESCRIPTION
creates a material query with id parameter, creates a function getMaterial that accepts the material_id which is an integer and passes it along in the resolvers

# Description

Created the ability to grab a material when passing it's corresponding ID

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Returns a single material when supplying a material_id

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
