### PR TITLE
Feature/28

### DIFF
--- a/src/resolvers.test.js
+++ b/src/resolvers.test.js
@@ -20,12 +20,18 @@ describe('[Query] in resolvers file', () => {
         { 
         description: "Crayons",
         material_id: "0",
-        long_description: "Can be donated or used as fire starters, OR MELTED INTO NEW CRAYONS. Why are you trying to throw away crayons, you dolt."
+        long_description: "Can be donated or used as fire starters, OR MELTED INTO NEW CRAYONS. Why are you trying to throw away crayons, you dolt.",
+        bin_trash: false,
+        bin_recycle: true,
+        bin_compost: false
       },
       {
         description: "T.P.",
         material_id: "007",
-        long_description: "They have a grave misunderstanding, the T actually stands for \"Tuxedo\""
+        long_description: "They have a grave misunderstanding, the T actually stands for \"Tuxedo\"",
+        bin_trash: "panda",
+        bin_recycle: true,
+        bin_compost: true
       }
     
      ]);
@@ -36,12 +42,18 @@ describe('[Query] in resolvers file', () => {
          [{ 
           description: "Crayons",
           material_id: "0",
-          long_description: "Can be donated or used as fire starters, OR MELTED INTO NEW CRAYONS. Why are you trying to throw away crayons, you dolt."
+          long_description: "Can be donated or used as fire starters, OR MELTED INTO NEW CRAYONS. Why are you trying to throw away crayons, you dolt.",
+          bin_trash: false,
+          bin_recycle: true,
+          bin_compost: false
         },
         {
           description: "T.P.",
           material_id: "007",
-          long_description: "They have a grave misunderstanding, the T actually stands for \"Tuxedo\""
+          long_description: "They have a grave misunderstanding, the T actually stands for \"Tuxedo\"",
+          bin_trash: false,
+          bin_recycle: true,
+          bin_compost: true
         }]
      )
 


### PR DESCRIPTION
# Description

**Will need update when materialReducer includes 4th boolean**

This actually tests the resolvers Querys, not the datasource functions which are on a different issue. 
Because we did not make a separate testing database, and we are relying on entries in the development database, I suggest we do not test model functions - only datasource and resolver. The models will be tested implicitly.

families query test did not need changes

Fixes #28 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] Jest
- [X] running scripts

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
