### PR TITLE
Add  multi-material by id query

### DIFF
--- a/src/datasources/earth.js
+++ b/src/datasources/earth.js
@@ -25,7 +25,7 @@ class EarthAPI extends RESTDataSource {
   }
 
   async familyReducer(family) {
-    const response = await CategoryImages.getImageURL(family.family_id)
+    const response = await CategoryImages.getImageURL(family.family_id);
     return {
       material_ids: family.material_ids,
       family_id: family.family_id,
@@ -95,8 +95,8 @@ class EarthAPI extends RESTDataSource {
     //extract just the location_id field from the data
     const locationIds = Array.isArray(locationsArr)
       ? locationsArr.map(location => {
-        return location.location_id;
-      })
+          return location.location_id;
+        })
       : [];
 
     //get location details for each location_id
@@ -117,6 +117,12 @@ class EarthAPI extends RESTDataSource {
       material => material.material_id === material_id
     )[0];
     return material;
+  }
+
+  async getMaterialByIDS(idList) {
+    const response = await this.getAllMaterials();
+    const materials = response.filter(mat => idList.includes(mat.material_id));
+    return materials;
   }
 
   // POSTAL DATA AND LAT/LONG

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -12,6 +12,8 @@ module.exports = {
       }),
     material: (_, { id }, { dataSources }) =>
       dataSources.earthAPI.getMaterial({ material_id: id }),
+    getMaterialByIDS: (_, { idList }, { dataSources }) =>
+      dataSources.earthAPI.getMaterialByIDS(idList),
     postal_code: (_, { postal_code, country }, { dataSources }) =>
       dataSources.earthAPI.getPostalData({
         postal_code: postal_code,

--- a/src/schema.js
+++ b/src/schema.js
@@ -4,6 +4,7 @@ const typeDefs = gql`
   type Query {
     material(id: Int): Material
     materials: [Material]
+    getMaterialByIDS(idList: [Int]): [Material]
     family: Family
     postal_code(postal_code: String!, country: String!): PostalCode
     families: [Family]


### PR DESCRIPTION
# Description

Adds a query "getMaterialByIDS" that allows you to select multiple materials using an id list/array.

Fixes #76 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Manual query test

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
